### PR TITLE
Support more Python versions

### DIFF
--- a/.pytype.cfg
+++ b/.pytype.cfg
@@ -2,6 +2,9 @@
 
 [pytype]
 
+# Python version (major.minor) of the target code.
+python_version = 3.6
+
 # Space-separated list of files or directories to exclude.
 exclude =
     **/*_test.py
@@ -23,9 +26,6 @@ output = .pytype
 # Paths to source code directories, separated by ':'.
 pythonpath =
     .
-
-# Python version (major.minor) of the target code.
-python_version = 3.6
 
 # Comma separated list of error names to ignore.
 disable =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,9 @@ readme = "README.md"
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "~3.6 || ~3.7"
 pyspark = "^2.4.1"
-
-# The dataclass module is not in the stdlib in Python 3.6
-dataclasses = { version = "~0.7.0", python="~3.6" }
+dataclasses = { version = "~0.7.0", python="~3.6" }  # The dataclass module is not in the stdlib in Python 3.6
 
 [tool.poetry.dev-dependencies]
 pytest = "~5.3"


### PR DESCRIPTION
closes https://github.com/mattjw/sparkql/issues/2

This should enable support for:

- Python 3.6 and 3.7
- PySpark 2.4.1 to 2.4.4

Python 3.8 support will come once PySpark supports 3.8. That won't be until the release of (Py)Spark 3.0.0: https://github.com/apache/spark/pull/26194