### PR TITLE
fix: Explicit array field not used in path str

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -277,3 +277,4 @@ dmypy.json
 
 .pytype
 reports/
+.venv

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,3 @@
+[virtualenvs]
+in-project = true
+virtualenvs.path = "./.venv"

--- a/sparkql/fields/array.py
+++ b/sparkql/fields/array.py
@@ -45,7 +45,7 @@ class Array(Generic[ArrayElementType], BaseField):
 
         # hand down this array's explicit name to its child element
         # this is to ensure correct naming in path chaining (see `self._replace_parent` and `path_seq`)
-        element = element._replace_explicit_name(name=self._explicit_name)
+        # element = element._replace_explicit_name(name=self._explicit_name)
         self.e = element  # pylint: disable=invalid-name
 
     #

--- a/sparkql/fields/array.py
+++ b/sparkql/fields/array.py
@@ -36,15 +36,15 @@ class Array(Generic[ArrayElementType], BaseField):
             raise ValueError(f"Array element must be a field. Found type: {type(element).__name__}")
 
         if element._resolve_field_name() is not None:
+            # we require that the array's element should be a "vanilla" field. it should not have been given
+            # any name (explicit nor contextual)
             raise ValueError(
                 "When using a field as the element field of an array, the field should not have a name. "
                 f"The field's name resolved to: {element._resolve_field_name()}"
             )
-            # None of the naming mechanics of this array's element type will be used.
-            # The name of the element type will not be used for anything
-            # ^ CORRECTION: child will get the parent's name
 
         # hand down this array's explicit name to its child element
+        # this is to ensure correct naming in path chaining (see `self._replace_parent` and `path_seq`)
         element = element._replace_explicit_name(name=self._explicit_name)
         self.e = element  # pylint: disable=invalid-name
 

--- a/sparkql/fields/array.py
+++ b/sparkql/fields/array.py
@@ -45,9 +45,7 @@ class Array(Generic[ArrayElementType], BaseField):
             # ^ CORRECTION: child will get the parent's name
 
         # hand down this array's explicit name to its child element
-        element = element._replace_explicit_name(
-            name=self._explicit_name
-        )
+        element = element._replace_explicit_name(name=self._explicit_name)
         self.e = element  # pylint: disable=invalid-name
 
     #

--- a/sparkql/fields/array.py
+++ b/sparkql/fields/array.py
@@ -30,12 +30,11 @@ class Array(Generic[ArrayElementType], BaseField):
     e: ArrayElementType  # pytype: disable=not-supported-yet  # pylint: disable=invalid-name
 
     def __init__(self, element: ArrayElementType, nullable: bool = True, name: Optional[str] = None):
-        super().__init__(nullable, name)
+        super().__init__(nullable=nullable, name=name)
 
         if not isinstance(element, BaseField):
             raise ValueError(f"Array element must be a field. Found type: {type(element).__name__}")
 
-        self.e = element  # pylint: disable=invalid-name
         if element._resolve_field_name() is not None:
             raise ValueError(
                 "When using a field as the element field of an array, the field should not have a name. "
@@ -43,6 +42,13 @@ class Array(Generic[ArrayElementType], BaseField):
             )
             # None of the naming mechanics of this array's element type will be used.
             # The name of the element type will not be used for anything
+            # ^ CORRECTION: child will get the parent's name
+
+        # hand down this array's explicit name to its child element
+        element = element._replace_explicit_name(
+            name=self._explicit_name
+        )
+        self.e = element  # pylint: disable=invalid-name
 
     #
     # Field path chaining

--- a/sparkql/fields/array.py
+++ b/sparkql/fields/array.py
@@ -45,7 +45,7 @@ class Array(Generic[ArrayElementType], BaseField):
 
         # hand down this array's explicit name to its child element
         # this is to ensure correct naming in path chaining (see `self._replace_parent` and `path_seq`)
-        # element = element._replace_explicit_name(name=self._explicit_name)
+        element = element._replace_explicit_name(name=self._explicit_name)
         self.e = element  # pylint: disable=invalid-name
 
     #

--- a/sparkql/fields/base.py
+++ b/sparkql/fields/base.py
@@ -71,8 +71,25 @@ class BaseField(ABC):
         field._parent_struct = parent  # pylint: disable=protected-access
         return field
 
+    def _replace_explicit_name(self, name: Optional[str] = None) -> "BaseField":
+        """
+        Return a copy of this field, with the explicit name set.
+
+        Should only be used for internal mechanics of handling name resolution during
+        path chaining.
+        """
+        field = copy.copy(self)
+        if self.__name_explicit is not None:
+            raise FieldParentError("Attempted to set an explicit name that has already been set")
+        field.__name_explicit = name
+        return field
+
     #
     # Field name management
+
+    @property
+    def _explicit_name(self) -> Optional[str]:
+        return self.__name_explicit
 
     @property
     def _contextual_name(self) -> Optional[str]:

--- a/sparkql/fields/base.py
+++ b/sparkql/fields/base.py
@@ -78,10 +78,10 @@ class BaseField(ABC):
         Should only be used for internal mechanics of handling name resolution during
         path chaining.
         """
-        field = copy.copy(self)
+        field: BaseField = copy.copy(self)
         if self.__name_explicit is not None:
             raise FieldParentError("Attempted to set an explicit name that has already been set")
-        field.__name_explicit = name
+        field.__name_explicit = name  # pylint: disable=protected-access
         return field
 
     #

--- a/sparkql/fields/base.py
+++ b/sparkql/fields/base.py
@@ -80,7 +80,7 @@ class BaseField(ABC):
         """
         field: BaseField = copy.copy(self)
         if self.__name_explicit is not None:
-            raise FieldParentError("Attempted to set an explicit name that has already been set")
+            raise FieldNameError("Attempted to set an explicit name that has already been set")
         field.__name_explicit = name  # pylint: disable=protected-access
         return field
 

--- a/tests/unit/test_accessors.py
+++ b/tests/unit/test_accessors.py
@@ -67,8 +67,12 @@ class TestPathStr:
 # << TO BE MOVED
 
 
+import pytest
+
+
 class TestPathStrForArray:
     @staticmethod
+    # @pytest.mark.only
     def should_use_explicit_name_for_array_field():
         # given (see above)
         class Element(Struct):
@@ -81,7 +85,8 @@ class TestPathStrForArray:
             root_field = StructWithArray(name="alt_root_field_name")
 
         # when
-        path = accessors.path_str(RootStruct.root_field.array_field.e.element_field)
+        obj = RootStruct.root_field.array_field.e.element_field
+        path = accessors.path_str(obj)
 
         # then
         assert path == "alt_root_field_name.alt_array_field_name.alt_element_field_name"
@@ -96,7 +101,8 @@ class TestPathStrForArray:
             array_field = Array(Element(), name="alt_array_field_name", nullable=True)
 
         # when
-        path = accessors.path_str(StructWithArray.array_field.e.element_field)
+        obj = StructWithArray.array_field.e.element_field
+        path = accessors.path_str(obj)
 
         # then
         assert path == "alt_array_field_name.alt_element_field_name"

--- a/tests/unit/test_accessors.py
+++ b/tests/unit/test_accessors.py
@@ -81,10 +81,10 @@ class TestPathStrForArray:
             root_field = StructWithArray(name="alt_root_field_name")
 
         # when
-        path_field_names = accessors.path_str(RootStruct.root_field.array_field.e.element_field)
+        path = accessors.path_str(RootStruct.root_field.array_field.e.element_field)
 
         # then
-        assert path_field_names == "alt_root_field_name.alt_array_field_name.alt_element_field_name"
+        assert path == "alt_root_field_name.alt_array_field_name.alt_element_field_name"
 
     @staticmethod
     def should_work_on_narrower_example():
@@ -96,10 +96,10 @@ class TestPathStrForArray:
             array_field = Array(Element(), name="alt_array_field_name", nullable=True)
 
         # when
-        path_field_names = accessors.path_str(StructWithArray.array_field.e.element_field)
+        path = accessors.path_str(StructWithArray.array_field.e.element_field)
 
         # then
-        assert path_field_names == "alt_array_field_name.alt_element_field_name"
+        assert path == "alt_array_field_name.alt_element_field_name"
 
 
 # >>

--- a/tests/unit/test_accessors.py
+++ b/tests/unit/test_accessors.py
@@ -41,6 +41,21 @@ class TestPathSeq:
         # then
         assert path_field_names == ["recipients", "full_name"]
 
+    @staticmethod
+    def test_should_return_correct_list_for_nested_array_with_explicit_field_name():
+        # given (see above)
+        class Element(Struct):
+            element_field = String(name="alt_element_field_name", nullable=True)
+
+        class StructWithArray(Struct):
+            array_field = Array(Element(), name="alt_array_field_name", nullable=True)
+
+        # when
+        path_field_names = accessors.path_seq(StructWithArray.array_field.e.element_field)
+
+        # then
+        assert path_field_names == ["alt_array_field_name", "alt_element_field_name"]
+
 
 class TestPathStr:
     @staticmethod
@@ -62,53 +77,6 @@ class TestPathStr:
 
         # then
         assert path_field_names == "recipients.full_name"
-
-
-# << TO BE MOVED
-
-
-import pytest
-
-
-class TestPathStrForArray:
-    @staticmethod
-    # @pytest.mark.only
-    def should_use_explicit_name_for_array_field():
-        # given (see above)
-        class Element(Struct):
-            element_field = String(name="alt_element_field_name", nullable=True)
-
-        class StructWithArray(Struct):
-            array_field = Array(Element(), name="alt_array_field_name", nullable=True)
-
-        class RootStruct(Struct):
-            root_field = StructWithArray(name="alt_root_field_name")
-
-        # when
-        obj = RootStruct.root_field.array_field.e.element_field
-        path = accessors.path_str(obj)
-
-        # then
-        assert path == "alt_root_field_name.alt_array_field_name.alt_element_field_name"
-
-    @staticmethod
-    def should_work_on_narrower_example():
-        # given (see above)
-        class Element(Struct):
-            element_field = String(name="alt_element_field_name", nullable=True)
-
-        class StructWithArray(Struct):
-            array_field = Array(Element(), name="alt_array_field_name", nullable=True)
-
-        # when
-        obj = StructWithArray.array_field.e.element_field
-        path = accessors.path_str(obj)
-
-        # then
-        assert path == "alt_array_field_name.alt_element_field_name"
-
-
-# >>
 
 
 class TestPathCol:

--- a/tests/unit/test_accessors.py
+++ b/tests/unit/test_accessors.py
@@ -64,6 +64,31 @@ class TestPathStr:
         assert path_field_names == "recipients.full_name"
 
 
+# << TO BE MOVED
+
+
+class TestPathStrForArray:
+    @staticmethod
+    def test_should_use_explicit_name_for_array_field():
+        # given (see above)
+        class Element(Struct):
+            element_field = String(name="alt_element_field_name", nullable=True)
+
+        class StructWithArray(Struct):
+            array_field = Array(Element(), name="alt_array_field_name", nullable=True)
+
+        class RootStruct(Struct):
+            root_field = StructWithArray(name="root_field_name")
+
+        # when
+        path_field_names = accessors.path_str(RootStruct.root_field.array_field.e.element_field)
+
+        # then
+        assert path_field_names == "root_field_name.alt_array_field_name.alt_element_field_name"
+
+
+# >>
+
 class TestPathCol:
     @staticmethod
     def test_should_return_correct_column_for_nested_schemas(spark_session: SparkSession):

--- a/tests/unit/test_accessors.py
+++ b/tests/unit/test_accessors.py
@@ -69,7 +69,7 @@ class TestPathStr:
 
 class TestPathStrForArray:
     @staticmethod
-    def test_should_use_explicit_name_for_array_field():
+    def should_use_explicit_name_for_array_field():
         # given (see above)
         class Element(Struct):
             element_field = String(name="alt_element_field_name", nullable=True)
@@ -78,16 +78,32 @@ class TestPathStrForArray:
             array_field = Array(Element(), name="alt_array_field_name", nullable=True)
 
         class RootStruct(Struct):
-            root_field = StructWithArray(name="root_field_name")
+            root_field = StructWithArray(name="alt_root_field_name")
 
         # when
         path_field_names = accessors.path_str(RootStruct.root_field.array_field.e.element_field)
 
         # then
-        assert path_field_names == "root_field_name.alt_array_field_name.alt_element_field_name"
+        assert path_field_names == "alt_root_field_name.alt_array_field_name.alt_element_field_name"
+
+    @staticmethod
+    def should_work_on_narrower_example():
+        # given (see above)
+        class Element(Struct):
+            element_field = String(name="alt_element_field_name", nullable=True)
+
+        class StructWithArray(Struct):
+            array_field = Array(Element(), name="alt_array_field_name", nullable=True)
+
+        # when
+        path_field_names = accessors.path_str(StructWithArray.array_field.e.element_field)
+
+        # then
+        assert path_field_names == "alt_array_field_name.alt_element_field_name"
 
 
 # >>
+
 
 class TestPathCol:
     @staticmethod

--- a/tests/unit/test_fields/test_base.py
+++ b/tests/unit/test_fields/test_base.py
@@ -61,3 +61,12 @@ class TestBaseField:
         # when, then
         with pytest.raises(FieldNameError):
             float_field._field_name
+
+    @staticmethod
+    def test_should_reject_replacing_a_preexisting_explicit_name():
+        # given
+        float_field = Float(name="explicit_name")
+
+        # wheb, then
+        with pytest.raises(FieldNameError):
+            float_field._replace_explicit_name("new_explicit_name")


### PR DESCRIPTION
Fixes a bug where an array field's explicit name was not being reflected in its path.

For example:

```
class Element(Struct):
    element_field = String(name="alt_element_field_name", nullable=True)

class StructWithArray(Struct):
    array_field = Array(Element(), name="alt_array_field_name", nullable=True)
```

We'd expect `accessors.path_seq(StructWithArray.array_field.e.element_field)` to use the explicit names, i.e. `["alt_array_field_name", "alt_element_field_name"]`. However, the bug ignored the array field's explicit name, giving the incorrect result:

```
["array_field", "alt_element_field_name"]
```
