### PR TITLE
fix: Fields should be hashable and have a sensible repr

### DIFF
--- a/sparkql/fields/array.py
+++ b/sparkql/fields/array.py
@@ -27,6 +27,8 @@ class Array(Generic[ArrayElementType], BaseField):
         etype: Data type info for the element of this array. Should be an instance of a `BaseField`.
     """
 
+    __hash__ = BaseField.__hash__
+
     e: ArrayElementType  # pytype: disable=not-supported-yet  # pylint: disable=invalid-name
 
     def __init__(self, element: ArrayElementType, nullable: bool = True, name: Optional[str] = None):

--- a/sparkql/fields/base.py
+++ b/sparkql/fields/base.py
@@ -18,7 +18,7 @@ def _validate_value_type_for_field(accepted_types: Tuple[Type, ...], value: Any)
     if value is not None and not isinstance(value, accepted_types):
         pretty_types = " ,".join("'" + accepted_type.__name__ + "'" for accepted_type in accepted_types)
         raise FieldValueValidationError(
-            f"Value '{value}' has invalid type '{type(value).__name__}'. Allowed types are: {pretty_types}"
+            f"Value '{value}' has invalid type '{value.__class__.__name__}'. Allowed types are: {pretty_types}"
         )
 
 
@@ -180,7 +180,7 @@ class BaseField(ABC):
     def _info(self):
         """String formatted object with a more complete summary of this field, primarily for debugging."""
         return (
-            f"<{type(self).__name__}\n"
+            f"<{self.__class__.__name__}\n"
             f"  spark type = {self._spark_type_class.__name__}\n"
             f"  nullable = {self._is_nullable}\n"
             f"  name = {self._resolve_field_name()} <- {[self.__name_explicit, self.__name_contextual]}\n"
@@ -190,7 +190,14 @@ class BaseField(ABC):
 
     def _short_info(self):
         """Short info string for use in error messages."""
-        return f"<{type(self).__name__}: nullable={self._is_nullable}>"
+        nullable = "Nullable " if self._is_nullable else ""
+        return f"<{nullable}{self.__class__.__name__}: {self._resolve_field_name()}>"
+
+    def __hash__(self):
+        return hash((self._is_nullable, self._resolve_field_name()))
+
+    def __repr__(self):
+        return self._short_info()
 
 
 class AtomicField(BaseField):

--- a/sparkql/fields/base.py
+++ b/sparkql/fields/base.py
@@ -116,7 +116,7 @@ class BaseField(ABC):
             )
         return name
 
-    def _resolve_field_name(self) -> Optional[str]:
+    def _resolve_field_name(self, default=None) -> Optional[str]:
         """
         Resolve name for this field, or None if no concrete name set.
 
@@ -126,7 +126,7 @@ class BaseField(ABC):
             return self.__name_explicit
         if self.__name_contextual is not None:
             return self.__name_contextual
-        return None
+        return default
 
     #
     # Spark type management
@@ -175,7 +175,7 @@ class BaseField(ABC):
         """Returns the name of this field."""
         # stringifying a field as its field adds some convenience for cases where we need the field
         # name
-        return self._resolve_field_name()
+        return self._resolve_field_name("")
 
     def _info(self):
         """String formatted object with a more complete summary of this field, primarily for debugging."""
@@ -194,7 +194,7 @@ class BaseField(ABC):
         return f"<{nullable}{self.__class__.__name__}: {self._resolve_field_name()}>"
 
     def __hash__(self):
-        return hash((self._is_nullable, self._resolve_field_name()))
+        return hash((self._is_nullable, self._resolve_field_name("")))
 
     def __repr__(self):
         return self._short_info()
@@ -212,6 +212,8 @@ class AtomicField(BaseField):
      |- ...
     ```
     """
+
+    __hash__ = BaseField.__hash__
 
     @property
     @abstractmethod

--- a/sparkql/fields/base.py
+++ b/sparkql/fields/base.py
@@ -194,7 +194,7 @@ class BaseField(ABC):
         return f"<{nullable}{self.__class__.__name__}: {self._resolve_field_name()}>"
 
     def __hash__(self):
-        return hash((self._is_nullable, self._resolve_field_name("")))
+        return hash((self._is_nullable, self._resolve_field_name(""), self._spark_type_class))
 
     def __repr__(self):
         return self._short_info()

--- a/sparkql/fields/struct.py
+++ b/sparkql/fields/struct.py
@@ -54,6 +54,7 @@ class ValidationResult:
 class Struct(BaseField):
     """A struct; shadows StructType in the Spark API."""
 
+    __hash__ = BaseField.__hash__
     _struct_metadata: ClassVar[Optional["_StructInnerMetadata"]] = None
 
     @classmethod

--- a/tests/unit/test_fields/test_array.py
+++ b/tests/unit/test_fields/test_array.py
@@ -79,3 +79,16 @@ class TestArrayField:
         # when, then
         with pytest.raises(ValueError, match=re.escape("Array element must be a field. Found type: str")):
             Array(bad_element)
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "instance",
+        [
+            pytest.param(Array(Float(), True, "name"), id="nullable instance"),
+            pytest.param(Array(Float(), False, "name"), id="non-nullable instance"),
+            pytest.param(Array(Float(), False), id="non-nullable nameless instance"),
+            pytest.param(Array(Float()), id="instance with default constructor"),
+        ],
+    )
+    def should_be_hashable(instance: Array):
+        _field_can_be_used_as_a_key = {instance: "value"}

--- a/tests/unit/test_fields/test_base.py
+++ b/tests/unit/test_fields/test_base.py
@@ -2,22 +2,58 @@ import pytest
 
 from sparkql.exceptions import FieldParentError, FieldNameError
 from sparkql import Float, Struct
+from sparkql.fields.base import BaseField
+
+
+@pytest.fixture()
+def float_field() -> Float:
+    return Float()
 
 
 class TestBaseField:
     @staticmethod
-    def should_give_correct_info_string():
-        # given
-        float_field = Float()
-
-        # when
-        info_str = float_field._info()
-
-        # then
+    def should_give_correct_info_string(float_field: Float):
         assert (
-            info_str
+            float_field._info()
             == "<Float\n  spark type = FloatType\n  nullable = True\n  name = None <- [None, None]\n  parent = None\n>"
         )
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "instance,expected_str",
+        [
+            pytest.param(Float(name="name"), "name", id="named instance"),
+            pytest.param(Float(), "", id="nameless instance with default constructor"),
+        ],
+    )
+    def should_have_a_string_representation_for(instance, expected_str):
+        assert str(instance) == expected_str
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "instance",
+        [
+            pytest.param(Float(True, "name"), id="nullable instance"),
+            pytest.param(Float(False, "name"), id="non-nullable instance"),
+            pytest.param(Float(False), id="non-nullable nameless instance"),
+            pytest.param(Float(), id="instance with default constructor"),
+        ],
+    )
+    def should_be_hashable(instance: Float):
+        _field_can_be_used_as_a_key = {instance: "value"}
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "instance,expected_repr",
+        [
+            pytest.param(Float(True, "name"), "<Nullable Float: name>", id="nullable instance"),
+            pytest.param(Float(False, "name"), "<Float: name>", id="non-nullable instance"),
+            pytest.param(Float(False), "<Float: None>", id="non-nullable nameless instance"),
+            pytest.param(Float(), "<Nullable Float: None>", id="instance with default constructor"),
+        ],
+    )
+    def should_have_a_readable_repr_for(instance, expected_repr):
+        assert repr(instance) == expected_repr
 
     @staticmethod
     def should_reject_setting_a_set_parent():
@@ -32,9 +68,8 @@ class TestBaseField:
             float_field._replace_parent(another_struct)
 
     @staticmethod
-    def should_get_contextual_field_name():
+    def should_get_contextual_field_name(float_field: Float):
         # given
-        float_field = Float()
         float_field._set_contextual_name("contextual_name")
 
         # when
@@ -44,9 +79,8 @@ class TestBaseField:
         assert contextual_name == "contextual_name"
 
     @staticmethod
-    def should_reject_overriding_a_set_contextual_name():
+    def should_reject_overriding_a_set_contextual_name(float_field: Float):
         # given
-        float_field = Float()
         float_field._set_contextual_name("contextual_name")
 
         # when, then
@@ -54,11 +88,7 @@ class TestBaseField:
             float_field._set_contextual_name("another_name")
 
     @staticmethod
-    def test_field_name_should_raise_error_if_not_resolved():
-        # given
-        float_field = Float()
-
-        # when, then
+    def test_field_name_should_raise_error_if_not_resolved(float_field: Float):
         with pytest.raises(FieldNameError):
             float_field._field_name
 

--- a/tests/unit/test_fields/test_struct.py
+++ b/tests/unit/test_fields/test_struct.py
@@ -7,6 +7,10 @@ from sparkql.exceptions import InvalidStructError
 from sparkql import Struct, String
 
 
+class MockStruct(Struct):
+    const = "HELLO"
+
+
 class TestStruct:
     @staticmethod
     def test_should_not_permit_field_overrides_of_internal_properties():
@@ -59,6 +63,13 @@ class TestStruct:
 
         # then
         assert value == "HELLO"
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "obj", [pytest.param(MockStruct(), id="as instance"), pytest.param(MockStruct, id="as class")]
+    )
+    def should_be_hashable(obj):
+        _field_can_be_used_as_a_key = {obj: "value"}
 
 
 class TestValidator:

--- a/tests/unit/test_fields/test_struct_implements.py
+++ b/tests/unit/test_fields/test_struct_implements.py
@@ -41,7 +41,7 @@ class TestStructImplements:
 
         assert str(err_info.value) == (
             "Struct 'ExampleStruct' implements field 'field_a' (required by struct 'SimpleStruct') but "
-            "field is not compatible. Required <String: nullable=True> but found <String: nullable=False>"
+            "field is not compatible. Required <Nullable String: field_a> but found <String: field_a>"
         )
 
     @staticmethod


### PR DESCRIPTION
1. Makes fields hashable so that they can be used as keys in Dict. Example:

`x = {MyStruct.field.sub_field: "hello"}`

2. Implements repr() representation to be readable in debugger/on printing:

`print(x)`

previously: `{<sparkql.fields.atomic.String object at 0x7f1bba5591d0>: 'hello'}`
now: `{<String: sub_field#keyword_cs>: 'hello'}`