### PR TITLE
feat: Update dependencies to Python 3.7+ and PySpark 3.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,12 +46,6 @@ jobs:
     docker:
       - image: mattjwnet/circleci-python-java11:py3.10.1
           # https://hub.docker.com/r/mattjwnet/circleci-python-java11
-        #auth:  #~
-        #  username: ${GITHUB_USERNAME}
-        #  password: ${GITHUB_DOCKER_READ_TOKEN}
-        # This is a public image (via Github Packages), so shouldn't need auth, but Github Packages does not yet
-        # support authless read from public images.
-        # https://github.community/t5/GitHub-Actions/docker-pull-from-public-GitHub-Package-Registry-fail-with-quot/td-p/32782
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,10 +105,8 @@ jobs:
     #   Exempting administrators will allow CircleCI (via the PAT) to push to master as part of a release.
     description: "Bump and release package to PyPI"
     docker:
-      - image: ghcr.io/mattjw/docker-images/circleci-python-java11:py3.10.1
-        auth:
-          username: ${GITHUB_USERNAME}
-          password: ${GITHUB_DOCKER_READ_TOKEN}
+      - image: mattjwnet/circleci-python-java11:py3.10.1
+          # https://hub.docker.com/r/mattjwnet/circleci-python-java11
     steps:
       - checkout
       - run:

--- a/README.md
+++ b/README.md
@@ -509,7 +509,6 @@ StructType([
         True)])
 ```
 
-
 ## Contributing
 
 Contributions are very welcome. Developers who'd like to contribute to


### PR DESCRIPTION
Releases changes added in https://github.com/mattjw/sparkql/pull/104. Addresses #103.

- Updates dependencies to more recent versions; most notably:
  - Update Python from 3.6 to >=3.7
  - Update `pyspark` from 2.4.1 to 3.x
  - Update the rest of dependencies to their most recent version
- Fix tests, mostly by adopting a more recent representation of stringified schema
- CI test runner now tests against Python 3.10, PySpark 3.x, and Java 11.