### PR TITLE
feat: add support for setting Decimal type precision and scale

### DIFF
--- a/examples/struct_instantiation/instantiate_as_dict.py
+++ b/examples/struct_instantiation/instantiate_as_dict.py
@@ -1,4 +1,5 @@
-from sparkql import Struct, String, Integer
+from sparkql import Struct, String, Integer, Decimal
+import decimal
 
 
 class User(Struct):
@@ -11,6 +12,7 @@ class Article(Struct):
     title = String()
     author = User()
     text = String(name="body")
+    print_price_usd = Decimal(1000, 2)
 
 
 article_a = Article.make_dict(
@@ -29,7 +31,8 @@ article_a_as_dict = {
         "user_id": 440,
         "username": "user"},
     "body": "Lorem ipsum article text lorem ipsum.",
-    "title": "The article title"
+    "title": "The article title",
+    "print_price_usd": None
 }
 
 
@@ -41,5 +44,20 @@ article_b_as_dict = {
     "article_id": 1002,
     "author": None,
     "body": None,
-    "title": None
+    "title": None,
+    "print_price_usd": None
+}
+
+
+article_c = Article.make_dict(
+    id=1003,
+    print_price_usd=decimal.Context(prec=3).create_decimal('1.99')
+)
+
+article_c_as_dict = {
+    "article_id": 1003,
+    "author": None,
+    "body": None,
+    "title": None,
+    "print_price_usd": decimal.Context(prec=3).create_decimal('1.99')
 }

--- a/examples/struct_instantiation/tests/test_example.py
+++ b/examples/struct_instantiation/tests/test_example.py
@@ -1,4 +1,8 @@
-from examples.struct_instantiation.instantiate_as_dict import article_a, article_a_as_dict, article_b, article_b_as_dict
+from examples.struct_instantiation.instantiate_as_dict import (
+    article_a, article_a_as_dict,
+    article_b, article_b_as_dict,
+    article_c, article_c_as_dict
+)
 
 
 def test_article_a():
@@ -7,3 +11,7 @@ def test_article_a():
 
 def test_article_b():
     assert article_b == article_b_as_dict
+
+
+def test_article_c():
+    assert article_c == article_c_as_dict

--- a/examples/validation/test_validation.py
+++ b/examples/validation/test_validation.py
@@ -2,15 +2,16 @@ import pytest
 from pyspark.sql import SparkSession
 
 from sparkql.exceptions import InvalidDataFrameError
-from sparkql import Struct, String
+from sparkql import Struct, String, Decimal
 
 
 def test_validation_example(spark_session: SparkSession):
-    dframe = spark_session.createDataFrame([{"title": "abc"}])
+    dframe = spark_session.createDataFrame([{"title": "abc", "print_price_usd": 1.99}])
 
     class Article(Struct):
         title = String()
         body = String()
+        print_price_usd = Decimal(100, 3)
 
     validation_result = Article.validate_data_frame(dframe)
 
@@ -19,19 +20,23 @@ def test_validation_example(spark_session: SparkSession):
 
 StructType([
     StructField('title', StringType(), True), 
-    StructField('body', StringType(), True)])
+    StructField('body', StringType(), True), 
+    StructField('print_price_usd', DecimalType(), True)])
 
 DataFrame schema...
 
 StructType([
+    StructField('print_price_usd', DoubleType(), True), 
     StructField('title', StringType(), True)])
 
 Diff of struct -> data frame...
 
   StructType([
+-     StructField('print_price_usd', DoubleType(), True), 
 -     StructField('title', StringType(), True)])
 +     StructField('title', StringType(), True), 
-+     StructField('body', StringType(), True)])"""
++     StructField('body', StringType(), True), 
++     StructField('print_price_usd', DecimalType(), True)])"""
 
     with pytest.raises(InvalidDataFrameError):
         Article.validate_data_frame(dframe).raise_on_invalid()

--- a/sparkql/fields/atomic.py
+++ b/sparkql/fields/atomic.py
@@ -65,9 +65,21 @@ class Short(IntegralField):
 class Decimal(FractionalField):
     """Field for Spark's DecimalType."""
 
+    __precision: int
+    __scale: int
+
+    def __init__(self, precision: int = 10, scale: int = 0, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.__precision = precision
+        self.__scale = scale
+
     @property
     def _spark_type_class(self) -> Type[DataType]:
         return DecimalType
+
+    @property
+    def _spark_data_type(self) -> DataType:
+        return DecimalType(self.__precision, self.__scale)
 
     def _validate_on_value(self, value: Any) -> None:
         super()._validate_on_value(value)

--- a/tests/unit/test_fields/test_atomic.py
+++ b/tests/unit/test_fields/test_atomic.py
@@ -61,6 +61,3 @@ def test_decimal_precision_and_scale():
 
     d = Decimal(12, 5)
     assert d._spark_data_type == DecimalType(12, 5)
-
-    d = Decimal(12, 5)
-    assert d._spark_data_type == DecimalType(12, 5)

--- a/tests/unit/test_fields/test_atomic.py
+++ b/tests/unit/test_fields/test_atomic.py
@@ -50,3 +50,17 @@ from sparkql.fields.atomic import (
 def test_atomics_have_correct_spark_type_classes(sparkql_field_class, spark_type_class):
     field_instance = sparkql_field_class()
     assert field_instance._spark_type_class is spark_type_class
+
+
+def test_decimal_precision_and_scale():
+    d = Decimal()
+    assert d._spark_data_type == DecimalType(10, 0)
+
+    d = Decimal(12)
+    assert d._spark_data_type == DecimalType(12, 0)
+
+    d = Decimal(12, 5)
+    assert d._spark_data_type == DecimalType(12, 5)
+
+    d = Decimal(12, 5)
+    assert d._spark_data_type == DecimalType(12, 5)

--- a/tests/unit/test_fields/test_atomic.py
+++ b/tests/unit/test_fields/test_atomic.py
@@ -52,12 +52,13 @@ def test_atomics_have_correct_spark_type_classes(sparkql_field_class, spark_type
     assert field_instance._spark_type_class is spark_type_class
 
 
-def test_decimal_precision_and_scale():
-    d = Decimal()
-    assert d._spark_data_type == DecimalType(10, 0)
-
-    d = Decimal(12)
-    assert d._spark_data_type == DecimalType(12, 0)
-
-    d = Decimal(12, 5)
-    assert d._spark_data_type == DecimalType(12, 5)
+@pytest.mark.parametrize(
+    "sparkql_field, spark_type",
+    [
+        [Decimal(), DecimalType(10, 0)],
+        [Decimal(12), DecimalType(12, 0)],
+        [Decimal(12, 5), DecimalType(12, 5)],
+    ],
+)
+def test_decimal_precision_and_scale(sparkql_field, spark_type):
+    assert sparkql_field._spark_data_type == spark_type


### PR DESCRIPTION
We have the need to specify Decimal precision and scale, but sparkql is currently missing this. This PR adds this support.