### PR TITLE
ci: Switch to read-write deploy keys, to allow CircleCI to write to Github during release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
           fingerprints:
             - "97:6d:ea:10:69:6d:d1:1c:b2:92:a5:a6:44:7f:cf:dd"
             # Use read-write deploy key here. So that CircleCI can write to the Github repo
-            # CircleCI deploy keys: https://app.circleci.com/settings/project/github/mattjw/sparkql/ssh?return-to=https%3A%2F%2Fapp.circleci.com%2Fpipelines%2Fgithub%2Fmattjw%2Fsparkql
+            # CircleCI deploy keys: https://app.circleci.com/settings/project/github/mattjw/sparkql/ssh
             # Github counterpart keys: https://github.com/mattjw/sparkql/settings/keys
       - run:
           name: Install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,20 +95,18 @@ jobs:
 
 
   release:
-    # Notes...
-    # - Requires a Github Personal Access Token as env var `GITHUB_WRITE_TOKEN`. Must have `repo` scope
-    # - The PAT is treated as Administrator. Suggested master branch protection rules as follows:
-    #     Require status checks to pass before merging = yes;
-    #     Require branches to be up to date before merging = yes;
-    #     Status checks = ci/circleci: build_verify (exclusively);
-    #     Include administrators = no
-    #   Exempting administrators will allow CircleCI (via the PAT) to push to master as part of a release.
     description: "Bump and release package to PyPI"
     docker:
       - image: mattjwnet/circleci-python-java11:py3.10.1
           # https://hub.docker.com/r/mattjwnet/circleci-python-java11
     steps:
       - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "97:6d:ea:10:69:6d:d1:1c:b2:92:a5:a6:44:7f:cf:dd"
+            # Use read-write deploy key here. So that CircleCI can write to the Github repo
+            # CircleCI deploy keys: https://app.circleci.com/settings/project/github/mattjw/sparkql/ssh?return-to=https%3A%2F%2Fapp.circleci.com%2Fpipelines%2Fgithub%2Fmattjw%2Fsparkql
+            # Github counterpart keys: https://github.com/mattjw/sparkql/settings/keys
       - run:
           name: Install dependencies
           command: |

--- a/tasks/releasing.py
+++ b/tasks/releasing.py
@@ -12,7 +12,6 @@ from .utils import run, PROJECT_INFO
 
 GITHUB_COMMITTER_USERNAME = "CI"
 GITHUB_COMMITTER_EMAIL = "mattjw+CI@mattjw.net"
-GITHUB_WRITE_TOKEN_ENV_VAR = "GITHUB_WRITE_TOKEN"
 
 #
 # Commands
@@ -107,22 +106,11 @@ def prepare_release():
 
 
 def github_push(branch: str):
-    """Push to branch (or tag) `branch`, using github write token."""
-    origin_url = run("git config --get remote.origin.url", warn=True, hide="stdout").stdout
-    match = re.match(r"git@github.com:(.+.git)", origin_url)
-    if match is None:
-        print(f"Unexpected github origin URL format: {origin_url}")
-        exit(1)
-    remote_url = "@github.com/" + match.group(1)
-    print(f"Using git remote: {remote_url}")
-
-    token = os.getenv(GITHUB_WRITE_TOKEN_ENV_VAR)
-    if token is None:
-        print(f"Could not find Github token in env var '{GITHUB_WRITE_TOKEN_ENV_VAR}'")
-        exit(1)
-
-    print(f"Pushing: {branch}")
-    run(f"git push https://{token}@${remote_url} {branch}", echo=False)  # never echo this; contains github token
+    """Push to branch (or tag) `branch`."""
+    # This assumes that the host machine has permission to push. Or, more formally,
+    # the account (i.e., SSH identity) is auth'd to do that push
+    remote = "origin"
+    run(f"git push {remote} {branch}", echo=False)
 
 
 @dataclass


### PR DESCRIPTION
Makes changes to the part of CI that carries out a release. Part of this involves pushing to the upstream Github repo from CircleCI.

Old process relied on a PAT. Instead, perhaps it can now use a read-write deploy key.